### PR TITLE
Sync 9b7f4813 - "Remove closing PHP tags from all examples"

### DIFF
--- a/src/annotations.rst
+++ b/src/annotations.rst
@@ -332,7 +332,7 @@ répétés pour chaque annotation ``@covers``. Voir
             $o->publicMethod();
         }
     }
-    ?>
+
 
 .. _appendixes.annotations.coversNothing:
 

--- a/src/assertions.rst
+++ b/src/assertions.rst
@@ -64,7 +64,7 @@ Signale une erreur identifiée par ``$message`` si le tableau ``$array`` ne disp
             $this->assertArrayHasKey('foo', ['bar' => 'baz']);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -110,7 +110,7 @@ Signale une erreur identifiée par ``$message`` si ``$className::attributeName``
             $this->assertClassHasAttribute('foo', stdClass::class);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -156,7 +156,7 @@ Signale une erreur identifiée par ``$message`` si ``$array`` ne contient pas le
             $this->assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -207,7 +207,7 @@ Signale une erreur identifiée par ``$message`` si ``$className::attributeName``
             $this->assertClassHasStaticAttribute('foo', stdClass::class);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -255,7 +255,7 @@ Signale une erreur identifiée par ``$message`` si ``$needle`` n'est pas un él�
             $this->assertContains(4, [1, 2, 3]);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -296,7 +296,7 @@ Si ``$ignoreCase`` est ``true``, ce test sera sensible à la casse.
             $this->assertContains('baz', 'foobar');
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -336,7 +336,7 @@ Si ``$ignoreCase`` est ``true``, ce test sera sensible à la casse.
             $this->assertContains('foo', 'FooBar', '', true);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -386,7 +386,7 @@ Signale une erreur identifiée par ``$message`` si ``$haystack`` ne contient pas
             $this->assertContainsOnly('string', ['1', '2', 3]);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -437,7 +437,7 @@ Signale une erreur identifiée par ``$message`` si ``$haystack`` ne contient pas
             );
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -483,7 +483,7 @@ Signale une erreur identifiée par ``$message`` si le nombre d'éléments dans `
             $this->assertCount(0, ['foo']);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -529,7 +529,7 @@ Signale une erreur identifiée par ``$message`` si le répertoire spécifié par
             $this->assertDirectoryExists('/path/to/directory');
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -575,7 +575,7 @@ Signale une erreur identifiée par ``$message`` si le répertoire spécifié par
             $this->assertDirectoryIsReadable('/path/to/directory');
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -621,7 +621,7 @@ Signale une erreur identifiée par ``$message`` si le répertoire spécifié par
             $this->assertDirectoryIsWritable('/path/to/directory');
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -669,7 +669,7 @@ Signale une erreur identifiée par ``$message`` si ``$actual`` n'est pas vide.
             $this->assertEmpty(['foo']);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -755,7 +755,7 @@ Signale une erreur identifiée par ``$message`` si la structure XML du DOMElemen
             );
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -840,7 +840,7 @@ Signale une erreur identifiée par ``$message`` si les deux variables ``$expecte
             $this->assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -911,7 +911,7 @@ Lisez "`What Every Computer Scientist Should Know About Floating-Point Arithmeti
             $this->assertEquals(1.0, 1.1);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -956,7 +956,7 @@ Signale une erreur identifiée par ``$message`` si la forme canonique sans comme
             $this->assertEquals($expected, $actual);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -1013,7 +1013,7 @@ Signale une erreur identifiée par ``$message`` si les deux objets ``$expected``
             $this->assertEquals($expected, $actual);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -1061,7 +1061,7 @@ Signale une erreur identifiée par ``$message`` si les deux tableaux ``$expected
             $this->assertEquals(['a', 'b', 'c'], ['a', 'c', 'd']);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -1117,7 +1117,7 @@ Signale une erreur identifiée par ``$message`` si ``$condition`` est ``true``.
             $this->assertFalse(true);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -1163,7 +1163,7 @@ Signale une erreur identifiée par ``$message`` si le fichier spécifié par ``$
             $this->assertFileEquals('/home/sb/expected', '/home/sb/actual');
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -1215,7 +1215,7 @@ Signale une erreur identifiée par ``$message`` si le fichier spécifié par ``$
             $this->assertFileExists('/path/to/file');
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -1261,7 +1261,7 @@ Signale une erreur identifiée par ``$message`` si le fichier spécifié par ``$
             $this->assertFileIsReadable('/path/to/file');
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -1307,7 +1307,7 @@ Signale une erreur identifiée par ``$message`` si le fichier spécifié par ``$
             $this->assertFileIsWritable('/path/to/file');
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -1353,7 +1353,7 @@ Signale une erreur identifiée par ``$message`` si la valeur de ``$actual`` n'es
             $this->assertGreaterThan(2, 1);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -1399,7 +1399,7 @@ Signale une erreur identifiée par ``$message`` si la valeur de ``$actual`` n'es
             $this->assertGreaterThanOrEqual(2, 1);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -1445,7 +1445,7 @@ Signale une erreur identifiée par ``$message`` si ``$variable`` n'est pas ``INF
             $this->assertInfinite(1);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -1493,7 +1493,7 @@ Signale une erreur identifiée par ``$message`` si ``$actual`` n'est pas une ins
             $this->assertInstanceOf(RuntimeException::class, new Exception);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -1541,7 +1541,7 @@ Signale une erreur identifiée par ``$message`` si ``$actual`` n'est pas du type
             $this->assertInternalType('string', 42);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -1587,7 +1587,7 @@ Signale une erreur identifiée par ``$message`` si le fichier ou le répertoire 
             $this->assertIsReadable('/path/to/unreadable');
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -1633,7 +1633,7 @@ Signale une erreur identifiée par ``$message`` si le fichier ou le répertoire 
             $this->assertIsWritable('/path/to/unwritable');
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -1679,7 +1679,7 @@ Signale une erreur identifiée par ``$message`` si la valeur de ``$actualFile`` 
               'path/to/fixture/file', 'path/to/actual/file');
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -1726,7 +1726,7 @@ Signale une erreur identifiée par ``$message`` si la valeur de ``$actualJson`` 
             );
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -1774,7 +1774,7 @@ Signale une erreur identifiée par ``$message`` si la valeur de ``$actualJson`` 
             );
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -1827,7 +1827,7 @@ Signale une erreur identifiée par ``$message`` si la valeur de ``$actual`` n'es
             $this->assertLessThan(1, 2);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -1873,7 +1873,7 @@ Signale une erreur identifiée par ``$message`` si la valeur de ``$actual`` n'es
             $this->assertLessThanOrEqual(1, 2);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -1917,7 +1917,7 @@ Signale une erreur identifiée par ``$message`` si ``$variable`` n'est pas ``NAN
             $this->assertNan(1);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -1963,7 +1963,7 @@ Signale une erreur identifiée par ``$message`` si ``$variable`` n'est pas ``nul
             $this->assertNull('foo');
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -2009,7 +2009,7 @@ Signale une erreur identifiée par ``$message`` si ``$object->attributeName`` n'
             $this->assertObjectHasAttribute('foo', new stdClass);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -2055,7 +2055,7 @@ Signale une erreur identifiée par ``$message`` si ``$string`` ne correspond pas
             $this->assertRegExp('/foo/', 'bar');
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -2101,7 +2101,7 @@ Signale une erreur identifiée par ``$message`` si  ``$string`` ne correspond pa
             $this->assertStringMatchesFormat('%i', 'foo');
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -2193,7 +2193,7 @@ Signale une erreur identifiée par ``$message`` si ``$string`` ne correspond pas
             $this->assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -2242,7 +2242,7 @@ Signale une erreur identifiée par ``$message`` si les deux variables ``$expecte
             $this->assertSame('2204', 2204);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -2281,7 +2281,7 @@ Signale une erreur identifiée par ``$message`` si les deux variables ``$expecte
             $this->assertSame(new stdClass, new stdClass);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -2327,7 +2327,7 @@ Signale une erreur identifiée par ``$message`` si ``$string`` ne termine pas pa
             $this->assertStringEndsWith('suffix', 'foo');
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -2373,7 +2373,7 @@ Signale une erreur identifiée par ``$message`` le fichier spécifié par ``$exp
             $this->assertStringEqualsFile('/home/sb/expected', 'actual');
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -2425,7 +2425,7 @@ Signale une erreur identifiée par ``$message`` si ``$string`` ne commence pas p
             $this->assertStringStartsWith('prefix', 'foo');
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -2485,7 +2485,7 @@ Signale une erreur identifiée par ``$message``si ``$value`` ne correspond pas �
             );
         }
     }
-    ?>
+
 
 :numref:`appendixes.assertions.assertThat.tables.constraints` montre les
 classes ``PHPUnit\Framework\Constraint`` disponibles.
@@ -2589,7 +2589,7 @@ Signale une erreur identifiée par ``$message`` si ``$condition`` est ``false``.
             $this->assertTrue(false);
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -2636,7 +2636,7 @@ Signale une erreur identifiée par ``$message`` si le document XML dans ``$actua
               '/home/sb/expected.xml', '/home/sb/actual.xml');
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -2691,7 +2691,7 @@ Signale une erreur identifiée par ``$message`` si le document XML dans ``$actua
               '/home/sb/expected.xml', '<foo><baz/></foo>');
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -2746,7 +2746,7 @@ Signale une erreur identifiée par ``$message`` si le document XML dans ``$actua
               '<foo><bar/></foo>', '<foo><baz/></foo>');
         }
     }
-    ?>
+
 
 .. code-block:: bash
 

--- a/src/code-coverage-analysis.rst
+++ b/src/code-coverage-analysis.rst
@@ -180,7 +180,7 @@ en utilisant les annotations ``@codeCoverageIgnore``,
     }
 
     exit; // @codeCoverageIgnore
-    ?>
+
 
 Les lignes de code ignorées (marquées comme ignorées à l'aide des annotations)
 sont comptées comme exécutées (si elles sont exécutables) et ne seront pas
@@ -273,7 +273,7 @@ montre un exemple.
             $this->assertSame(0, $this->ba->getBalance());
         }
     }
-    ?>
+
 
 Il est également possible d'indiquer qu'un test ne doit couvrir
 *aucune* méthode en utilisant l'annotation
@@ -309,7 +309,7 @@ ne générez une couverture de code avec des tests unitaires.
             $this->assertTablesEqual($expectedTable, $queryTable);
         }
     }
-    ?>
+
 
 .. _code-coverage-analysis.edge-cases:
 
@@ -340,4 +340,4 @@ de couverture de code prêtant à confusion.
     if (false) {
         this_call_will_never_show_up_as_covered();
     }
-    ?>
+

--- a/src/database.rst
+++ b/src/database.rst
@@ -209,7 +209,7 @@ hériter de la classe
             $this->assertSame(2, 1 + 1);
         }
     }
-    ?>
+
 
 Si vous voulez tester du code qui fonctionne avec l'extension base de données,
 le setup sera un peu plus complexe et vous devrez hériter d'un cas de test
@@ -244,7 +244,7 @@ abstrait différent qui nécessite que vous implémentiez deux méthodes abstrai
             return $this->createFlatXMLDataSet(dirname(__FILE__).'/_files/guestbook-seed.xml');
         }
     }
-    ?>
+
 
 .. _database.implementing-getconnection:
 
@@ -360,7 +360,7 @@ d'indiquer des données de fixture différentes pour chaque cas de test :
             return $this->conn;
         }
     }
-    ?>
+
 
 Mais la connexion à la base de données reste codée en dur dans la
 connexion PDO. PHPUnit possède une autre fonctionnalité formidable
@@ -412,7 +412,7 @@ Nous pouvons maintenant modifier notre cas de test pour qu'il ressemble à ça :
             return $this->conn;
         }
     }
-    ?>
+
 
 Nous pouvons maintenant lancer la suite de tests de la base de données en utilisant différentes
 configurations depuis l'interface en ligne de commandes:
@@ -611,7 +611,7 @@ dans votre cas de test de base de données en appelant la méthode
             return $this->createFlatXmlDataSet('myFlatXmlFixture.xml');
         }
     }
-    ?>
+
 
 .. _database.xml-dataset:
 
@@ -680,7 +680,7 @@ cas de test de base de données en appelant la méthode
             return $this->createXMLDataSet('myXmlFixture.xml');
         }
     }
-    ?>
+
 
 .. _database.mysql-xml-dataset:
 
@@ -719,7 +719,7 @@ la méthode ``createMySQLXMLDataSet($filename)``:
             return $this->createMySQLXMLDataSet('/path/to/file.xml');
         }
     }
-    ?>
+
 
 .. _database.yaml-dataset:
 
@@ -766,7 +766,7 @@ pour le cas de tests de base de données, si bien que vous devez l'instancier ma
             return new YamlDataSet(dirname(__FILE__)."/_files/guestbook.yml");
         }
     }
-    ?>
+
 
 .. _database.csv-dataset:
 
@@ -808,7 +808,7 @@ Vous pouvez créer un dataset CSV en appelant :
             return $dataSet;
         }
     }
-    ?>
+
 
 .. _database.array-dataset:
 
@@ -851,7 +851,7 @@ facilement la vôtre. Notre exemple du Livre d'or devrait ressembler à :
             );
         }
     }
-    ?>
+
 
 Un DataSet PHP possède des avantages évidents sur les autres datasets utilisant des
 fichiers :
@@ -925,7 +925,7 @@ L'implémentation de ce DataSet tableau est simple et
             return $this->tables[$tableName];
         }
     }
-    ?>
+
 
 .. _database.query-sql-dataset:
 
@@ -941,7 +941,7 @@ qui contiennent le contenu constaté de la base de données. C'est là que le Da
     <?php
     $ds = new PHPUnit\DbUnit\DataSet\QueryDataSet($this->getConnection());
     $ds->addTable('guestbook');
-    ?>
+
 
 Ajouter une table juste par son nom est un moyen implicite de définir
 la table de données avec la requête suivante :
@@ -951,7 +951,7 @@ la table de données avec la requête suivante :
     <?php
     $ds = new PHPUnit\DbUnit\DataSet\QueryDataSet($this->getConnection());
     $ds->addTable('guestbook', 'SELECT * FROM guestbook');
-    ?>
+
 
 Vous pouvez utiliser ceci en indiquant des requêtes arbitraires pour
 vos tables, par exemple en restreignant les lignes, les colonnes ou en
@@ -962,7 +962,7 @@ ajoutant des clauses ``ORDER BY``:
     <?php
     $ds = new PHPUnit\DbUnit\DataSet\QueryDataSet($this->getConnection());
     $ds->addTable('guestbook', 'SELECT id, content FROM guestbook ORDER BY created DESC');
-    ?>
+
 
 La section relative aux assertions de base de données montrera plus en détails comment
 utiliser le Query DataSet.
@@ -1017,7 +1017,7 @@ la méthode ``testFilteredGuestbook()``.
             // ...
         }
     }
-    ?>
+
 
 .. _database.replacement-dataset:
 
@@ -1061,7 +1061,7 @@ Nous encapsulons le DataSet au format XML à plat dans le DataSet de remplacemen
             return $rds;
         }
     }
-    ?>
+
 
 .. _database.dataset-filter:
 
@@ -1105,7 +1105,7 @@ particulièrement commode en combinaison avec le DataSet de base de données pou
             // ..
         }
     }
-    ?>
+
 
 .. admonition:: Note
 
@@ -1164,7 +1164,7 @@ En utiliser le DataSet composite, nous pouvons agréger les deux fichiers de fix
             return $compositeDs;
         }
     }
-    ?>
+
 
 .. _database.beware-of-foreign-keys:
 
@@ -1200,7 +1200,7 @@ si vous ne projetez pas d'implémenter votre propre DataSet ou DataTable.
 
         public function getReverseIterator();
     }
-    ?>
+
 
 L'interface publique est utilisée en interne par l'assertion
 ``assertDataSetsEqual()`` du cas de test de base de données
@@ -1232,7 +1232,7 @@ Une table est également représentée par l'interface suivante :
         public function getRow($row);
         public function assertEquals(ITable $other);
     }
-    ?>
+
 
 Mise à part la méthode ``getTableMetaData()``, ça parle
 plutôt de soi-même. Les méthodes utilisées sont toutes nécessaires pour
@@ -1283,7 +1283,7 @@ qui doit être retournée par la méthode
 
         // ...
     }
-    ?>
+
 
 #.
 
@@ -1306,7 +1306,7 @@ qui doit être retournée par la méthode
                $dataSet = $this->getConnection()->createDataSet();
            }
        }
-       ?>
+
 
 #.
 
@@ -1332,7 +1332,7 @@ qui doit être retournée par la méthode
                $queryTable = $this->getConnection()->createQueryTable('guestbook', 'SELECT * FROM guestbook');
            }
        }
-       ?>
+
 
 #.
 
@@ -1356,7 +1356,7 @@ qui doit être retournée par la méthode
                $this->assertSame(2, $this->getConnection()->getRowCount('guestbook'));
            }
        }
-       ?>
+
 
 .. _database.database-assertions-api:
 
@@ -1400,7 +1400,7 @@ qui nous ont accompagnées dans tous les exemples précédents, mais aussi une t
             $this->assertSame(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
         }
     }
-    ?>
+
 
 .. _database.asserting-the-state-of-a-table:
 
@@ -1439,7 +1439,7 @@ son contenu d'un nom de table et d'une requête SQL et le compare
             $this->assertTablesEqual($expectedTable, $queryTable);
         }
     }
-    ?>
+
 
 Maintenant, nous devons écrire le fichier XML à plat *expectedBook.xml*
 pour cette assertion :
@@ -1480,7 +1480,7 @@ Nous devons corriger l'appel à Query Table:
     $queryTable = $this->getConnection()->createQueryTable(
         'guestbook', 'SELECT id, content, user FROM guestbook'
     );
-    ?>
+
 
 .. _database.asserting-the-result-of-a-query:
 
@@ -1511,7 +1511,7 @@ d'un résultat avec une requête et en le comparant avec un ensemble de données
             $this->assertTablesEqual($expectedTable, $queryTable);
         }
     }
-    ?>
+
 
 .. _database.asserting-the-state-of-multiple-tables:
 
@@ -1544,7 +1544,7 @@ basé sur un fichier. Il y a deux façons différentes de faire des assertions d
                $this->assertDataSetsEqual($expectedDataSet, $dataSet);
            }
        }
-       ?>
+
 
 #.
 
@@ -1570,7 +1570,7 @@ basé sur un fichier. Il y a deux façons différentes de faire des assertions d
                $this->assertDataSetsEqual($expectedDataSet, $dataSet);
            }
        }
-       ?>
+
 
 .. _database.frequently-asked-questions:
 

--- a/src/extending-phpunit.rst
+++ b/src/extending-phpunit.rst
@@ -72,7 +72,7 @@ de suivre la façon dont PHPUnit implémente ses propres assertions. Comme vous 
         }
 
         // ...
-    }?>
+    }
 
 :numref:`extending-phpunit.examples.IsTrue.php` montre comment
 ``PHPUnit\Framework\Constraint\IsTrue`` étend la classe
@@ -111,7 +111,7 @@ abstraite de base pour des objets matcher (ou des contraintes),
         {
             return 'is true';
         }
-    }?>
+    }
 
 L'effort d'implémentation des méthodes ``assertTrue()`` et
 ``isTrue()`` ainsi que la classe
@@ -185,7 +185,7 @@ montre une implémentation simple de l'interface
             printf("TestSuite '%s' ended.\n", $suite->getName());
         }
     }
-    ?>
+
 
 :numref:`extending-phpunit.examples.BaseTestListener.php`
 montre comment étendre la classe abstraite
@@ -207,7 +207,7 @@ tous les autres.
             printf("Test '%s' ended.\n", $test->getName());
         }
     }
-    ?>
+
 
 Dans :ref:`appendixes.configuration.test-listeners` vous pouvez voir
 comment configurer PHPUnit pour brancher votre moniteur de test lors de l'exécution
@@ -293,7 +293,7 @@ et la seconde valeur celle constatée.
 
     $test = new DataDrivenTest('data_file.csv');
     $result = PHPUnit\TextUI\TestRunner::run($test);
-    ?>
+
 
 .. code-block:: bash
 

--- a/src/fixtures.rst
+++ b/src/fixtures.rst
@@ -78,7 +78,7 @@ de test et nous utilisons la variable d'instance nouvellement introduite.
             $this->assertTrue(empty($this->stack));
         }
     }
-    ?>
+
 
 Les méthodes template ``setUp()`` et ``tearDown()``
 sont exécutées une fois pour chaque méthode de test (et pour les nouvelles instances)
@@ -149,7 +149,7 @@ dans une classe de cas de test.
             throw $e;
         }
     }
-    ?>
+
 
 .. code-block:: bash
 
@@ -257,7 +257,7 @@ de déconnecter de la base de données après le dernier test du cas de test.
             self::$dbh = null;
         }
     }
-    ?>
+
 
 On n'insistera jamais assez sur le fait que partager les fixtures
 entre les tests réduit la valeur de ces tests. Le problème de conception

--- a/src/incomplete-and-skipped-tests.rst
+++ b/src/incomplete-and-skipped-tests.rst
@@ -66,7 +66,7 @@ dans la méthode de test, nous marquons le test comme étant incomplet.
             );
         }
     }
-    ?>
+
 
 Un test incomplet est signalé par un ``I`` sur la sortie écran
 du lanceur de test en ligne de commandes PHPUnit, comme montré dans l'exemple
@@ -145,7 +145,7 @@ pour sauter le test si ce n'est pas le cas.
             // ...
         }
     }
-    ?>
+
 
 Un test qui a été sauté est signalé par un ``S`` dans la sortie
 écran du lanceur de tests en ligne de commande PHPUnit, comme montré dans
@@ -248,7 +248,7 @@ l'annotation ``@requires`` pour exprimer les préconditions communes pour un cas
 
         // ... All other tests require the mysqli extension
     }
-    ?>
+
 
 Si vous utilisez une syntaxe qui ne compile pas avec une version donnée de PHP, regardez
 dans la configuration xml pour les inclusions dépendant de la version dans :ref:`appendixes.configuration.testsuites`

--- a/src/test-doubles.rst
+++ b/src/test-doubles.rst
@@ -93,7 +93,7 @@ comme montré dans l'exemple. Ceci amène à un code plus lisible et "souple".
             // Do something.
         }
     }
-    ?>
+
 
 .. code-block:: php
     :caption: Bouchonner un appel de méthode pour retourner une valeur fixée
@@ -118,7 +118,7 @@ comme montré dans l'exemple. Ceci amène à un code plus lisible et "souple".
             $this->assertSame('foo', $stub->doSomething());
         }
     }
-    ?>
+
 
 .. admonition:: Limitation: Méthodes nommées "method"
 
@@ -164,7 +164,7 @@ utilise les même bonnes pratiques utilisées par défaut par ``createMock()``.
             $this->assertSame('foo', $stub->doSomething());
         }
     }
-    ?>
+
 
 Dans les exemples précédents, nous avons retourné des valeurs simple en utilisant
 ``willReturn($value)``. Cette syntaxe courte est identique à
@@ -202,7 +202,7 @@ pouvez obtenir ceci en utilisant ``returnArgument()`` à la place de
             $this->assertSame('bar', $stub->doSomething('bar'));
         }
     }
-    ?>
+
 
 Quand on teste interface souple, il est parfois utile que la méthode bouchon
 retourne une référence à l'objet bouchon.
@@ -231,7 +231,7 @@ utiliser ``returnSelf()`` pour accomplir cela.
             $this->assertSame($stub, $stub->doSomething());
         }
     }
-    ?>
+
 
 Parfois, une méthode bouchon doit retourner différentes valeurs selon
 une liste prédéfinie d'arguments. Vous pouvez utiliser
@@ -270,7 +270,7 @@ un exemple.
             $this->assertSame('h', $stub->doSomething('e', 'f', 'g'));
         }
     }
-    ?>
+
 
 Quand l'appel d'une méthode bouchonné doit retourner une valeur calculée au lieu
 d'une valeur fixée (voir ``returnValue()``) ou un paramètre
@@ -301,7 +301,7 @@ d'une fonction ou méthode de rappel. Voir
             $this->assertSame('fbzrguvat', $stub->doSomething('something'));
         }
     }
-    ?>
+
 
 Une alternative plus simple à la configuration d'une méthode de rappel peut
 consister à indiquer une liste de valeurs désirées. Vous pouvez faire
@@ -333,7 +333,7 @@ un exemple.
             $this->assertSame(5, $stub->doSomething());
         }
     }
-    ?>
+
 
 Au lieu de retourner une valeur, une méthode bouchon peut également lever
 une exception. :numref:`test-doubles.stubs.examples.StubTest8.php`
@@ -361,7 +361,7 @@ montre comme utiliser ``throwException()`` pour faire cela.
             $stub->doSomething();
         }
     }
-    ?>
+
 
 Alternativement, vous pouvez écrire le bouchon vous-même et améliorer votre conception
 en cours de route. Des ressources largement utilisées sont accédées via une unique façade,
@@ -477,7 +477,7 @@ qui sont une partie du système testé (SUT).
 
         // Autre méthodes
     }
-    ?>
+
 
 :numref:`test-doubles.mock-objects.examples.SubjectTest.php`
 illustre comment utiliser un mock pour tester l'interaction entre
@@ -529,7 +529,7 @@ et ``with()`` pour spécifier comment cette interaction doit se présenter.
             $subject->doSomething();
         }
     }
-    ?>
+
 
 La méthode ``with()`` peut prendre n'importe quel
 nombre de paramètres, correspondant au nombre de paramètres des méthodes
@@ -569,7 +569,7 @@ correspondance, sur les paramètres de méthode.
             $subject->doSomethingBad();
         }
     }
-    ?>
+
 
 La méthode ``withConsecutive()`` peut prendre n'importe quel
 nombre de tableau de paramètres, selon les appels que vous souhaitez tester.
@@ -602,7 +602,7 @@ méthode mockée, comme avec ``with()``.
             $mock->set('bar', 48);
         }
     }
-    ?>
+
 
 La contrainte ``callback()`` peut être utilisée pour une vérification
 plus complexe d'un argument. Cette contrainte prend comme seul paramètre une fonction de
@@ -644,7 +644,7 @@ passe la vérification et ``false`` sinon.
             $subject->doSomethingBad();
         }
     }
-    ?>
+
 
 .. code-block:: php
     :caption: Tester qu'une méthode est appelée une seule fois avec le même objet qui a été passé
@@ -670,7 +670,7 @@ passe la vérification et ``false`` sinon.
             $mock->foo($expectedObject);
         }
     }
-    ?>
+
 
 .. code-block:: php
     :caption: Créer un OBJET mock avec les paramètres de clonage activés
@@ -693,7 +693,7 @@ passe la vérification et ``false`` sinon.
             // échouera.
         }
     }
-    ?>
+
 
 :ref:`appendixes.assertions.assertThat.tables.constraints`
 montre les contraintes qui peuvent être appliquées aux paramètres de méthode et
@@ -811,7 +811,7 @@ révélations:
             $subject->doSomething();
         }
     }
-    ?>
+
 
 Reportez-vous à la `documentation <https://github.com/phpspec/prophecy#how-to-use-it>`_
 de Prophecy pour plus de détails sur la création, la configuration et l'utilisation de
@@ -856,7 +856,7 @@ sont mockées. Cela permet de tester les méthodes concrètes d'un Trait.
             $this->assertTrue($mock->concreteMethod());
         }
     }
-    ?>
+
 
 La méthode ``getMockForAbstractClass()`` retourne un mock
 pour une classe abstraite. Toutes les méthodes abstraites d'une classe mock
@@ -893,7 +893,7 @@ abstraite.
             $this->assertTrue($stub->concreteMethod());
         }
     }
-    ?>
+
 
 .. _test-doubles.stubbing-and-mocking-web-services:
 
@@ -980,7 +980,7 @@ par exemple, d'un web service décrit dans :file:`GoogleSearch.wsdl`.
             );
         }
     }
-    ?>
+
 
 .. _test-doubles.mocking-the-filesystem:
 
@@ -1037,7 +1037,7 @@ montre une classe qui interagit avec le système de fichiers.
                 mkdir($this->directory, 0700, true);
             }
         }
-    }?>
+    }
 
 Sans un système de fichiers virtuel tel que vfsStream, nous ne pouvons
 pas tester la méthode ``setDirectory()`` en isolation des influences
@@ -1075,7 +1075,7 @@ extérieures (voir :numref:`test-doubles.mocking-the-filesystem.examples.Example
             }
         }
     }
-    ?>
+
 
 L'approche précédente possède plusieurs inconvénients :
 
@@ -1119,7 +1119,7 @@ pour une classe qui interagit avec le système de fichiers.
             $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
         }
     }
-    ?>
+
 
 Ceci présente plusieurs avantages :
 

--- a/src/textui.rst
+++ b/src/textui.rst
@@ -292,7 +292,7 @@ dans le code suivant :
                     ];
                 }
             }
-            ?>
+
 
     ``/path/to/my/test.phpt``
 


### PR DESCRIPTION
- [ ] [9b7f4813 - Remove closing PHP tags from all examples ](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/9b7f481320f8fa7b72d209a1a421f6cc3bd78306)