### PR TITLE
Sync 375475 - Remove an empty code block before @testWith

### DIFF
--- a/src/annotations.rst
+++ b/src/annotations.rst
@@ -763,8 +763,6 @@ L'annotation ``@testdox`` peut être appliqué aux classes de tests et aux méth
     l'annotation ``@testdox`` active aussi le comportement
     de l'annotation ``@test``.
 
-.. code-block:: php
-
 .. _appendixes.annotations.testWith:
 
 @testWith


### PR DESCRIPTION
- [x] [375475 - Remove an empty code block before @testWith](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/3754756addadd81b3c7c2198f92b95dda3e15d13)