### PR TITLE
2db7326 - Fix code indentation of example in extending-phpunit.rst -

### DIFF
--- a/src/extending-phpunit.rst
+++ b/src/extending-phpunit.rst
@@ -354,23 +354,23 @@ d'une extension implémentant ``BeforeFirstTestHook`` et ``AfterLastTestHook`` :
     :caption: Exemple d'extension TestRunner
     :name: extending-phpunit.examples.TestRunnerExtension
 
-        <?php
+    <?php
 
-        namespace Vendor;
+    namespace Vendor;
 
-        use PHPUnit\Runner\AfterLastTestHook;
-        use PHPUnit\Runner\BeforeFirstTestHook;
+    use PHPUnit\Runner\AfterLastTestHook;
+    use PHPUnit\Runner\BeforeFirstTestHook;
 
-        final class MyExtension implements BeforeFirstTestHook, AfterLastTestHook
+    final class MyExtension implements BeforeFirstTestHook, AfterLastTestHook
+    {
+        public function executeAfterLastTest(): void
         {
-            public function executeAfterLastTest(): void
-            {
-                // called after the last test has been run
-            }
-
-            public function executeBeforeFirstTest(): void
-            {
-                // called before the first test is being run
-            }
+            // called after the last test has been run
         }
+
+        public function executeBeforeFirstTest(): void
+        {
+            // called before the first test is being run
+        }
+    }
 


### PR DESCRIPTION
  - [x] [2db7326 - Fix code indentation of example in extending-phpunit.rst](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/2db7326a5427859bb1348fa0ae52b061cbf303d7) 