### PR TITLE
Synch - 91739031fd - Remove inline literal syntax for descriptions

### DIFF
--- a/src/annotations.rst
+++ b/src/annotations.rst
@@ -281,25 +281,25 @@ la syntaxe de l'annotation ``@covers``.
     * - Annotation
       - Description
     * - ``@covers ClassName::methodName``
-      - ``Indique que la méthode de test annotée couvre la méthode indiquée.``
+      - Indique que la méthode de test annotée couvre la méthode indiquée.
     * - ``@covers ClassName``
-      - ``Indique que la méthode de test annotée couvre toutes les méthodes d'une classe donnée.``
+      - Indique que la méthode de test annotée couvre toutes les méthodes d'une classe donnée.
     * - ``@covers ClassName<extended>``
-      - ``Indique que la méthode de test annotée couvre toutes les méthodes d'une classe donnée ainsi que les classe(s) et interface(s) parentes.``
+      - Indique que la méthode de test annotée couvre toutes les méthodes d'une classe donnée ainsi que les classe(s) et interface(s) parentes.
     * - ``@covers ClassName::<public>``
-      - ``Indique que la méthode de test annotée couvre toutes les méthodes publiques d'une classe donnée.``
+      - Indique que la méthode de test annotée couvre toutes les méthodes publiques d'une classe donnée.
     * - ``@covers ClassName::<protected>``
-      - ``Indique que la méthode de test annotée couvre toutes les méthodes protected d'une classe donnée.``
+      - Indique que la méthode de test annotée couvre toutes les méthodes protected d'une classe donnée.
     * - ``@covers ClassName::<private>``
-      - ``Indique que la méthode de test annotée couvre toutes les méthodes privées d'une classe donnée.``
+      - Indique que la méthode de test annotée couvre toutes les méthodes privées d'une classe donnée.
     * - ``@covers ClassName::<!public>``
-      - ``Indique que la méthode de test annotée couvre toutes les méthodes d'une classe donnée qui ne sont pas publiques.``
+      - Indique que la méthode de test annotée couvre toutes les méthodes d'une classe donnée qui ne sont pas publiques.
     * - ``@covers ClassName::<!protected>``
-      - ``Indique que la méthode de test annotée couvre toutes les méthodes d'une classe donnée qui ne sont pas protected.``
+      - Indique que la méthode de test annotée couvre toutes les méthodes d'une classe donnée qui ne sont pas protected.
     * - ``@covers ClassName::<!private>``
-      - ``Indique que la méthode de test annotée couvre toutes les méthodes d'une classe donnée qui ne sont pas privées.``
+      - Indique que la méthode de test annotée couvre toutes les méthodes d'une classe donnée qui ne sont pas privées.
     * - ``@covers ::functionName``
-      - ``Indique que la méthode de test annotée couvre la méthode globale spécifiée.``
+      - Indique que la méthode de test annotée couvre la méthode globale spécifiée.
 
 .. _appendixes.annotations.coversDefaultClass:
 


### PR DESCRIPTION
  - [x] [91739031fd - Remove inline literal syntax for descriptions](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/91739031fdfa5dce308e5c7e425b95007ff0aa6b)