### PR TITLE
synchro 7.0

### DIFF
--- a/src/assertions.rst
+++ b/src/assertions.rst
@@ -2529,7 +2529,7 @@ classes ``PHPUnit\Framework\Constraint`` disponibles.
       - La contrainte qui valide que la classe évaluée possède un attribut donné.
     * - ``PHPUnit\Framework\Constraint\ClassHasStaticAttribute classHasStaticAttribute(string $attributeName)``
       - La contrainte qui valide que la classe évaluée possède un attribut statique donné.
-    * - ``PHPUnit\Framework\Constraint\ObjectHasAttribute hasAttribute(string $attributeName)``
+    * - ``PHPUnit\Framework\Constraint\ObjectHasAttribute objectHasAttribute(string $attributeName)``
       - La contrainte qui valide que l'objet évalué possède un attribut donné.
     * - ``PHPUnit\Framework\Constraint\IsIdentical identicalTo(mixed $value)``
       - Contrainte qui valide qu'une valeur est identique à une autre.
@@ -2774,5 +2774,3 @@ Signale une erreur identifiée par ``$message`` si le document XML dans ``$actua
 
     FAILURES!
     Tests: 1, Assertions: 1, Failures: 1.
-
-

--- a/src/configuration.rst
+++ b/src/configuration.rst
@@ -372,4 +372,10 @@ La configuration XML ci-dessus correspond au code PHP suivant :
     $_FILES['foo'] = 'bar';
     $_REQUEST['foo'] = 'bar';
 
+Par défaut, les variables d'environnement ne sont pas écrasées si elles existent déjà.
+Pour forcer l'écrasement de variables existantes, utilisez l'attribut ``force`` :
 
+.. code-block:: xml
+
+    <php>
+      <env name="foo" value="bar" force="true"/>

--- a/src/configuration.rst
+++ b/src/configuration.rst
@@ -28,7 +28,6 @@ utilisés pour configurer les fonctionnalités du coeur de PHPUnit.
              convertNoticesToExceptions="true"
              convertWarningsToExceptions="true"
              forceCoversAnnotation="false"
-             mapTestClassNameToCoveredClassName="false"
              printerClass="PHPUnit\TextUI\ResultPrinter"
              <!--printerFile="/path/to/ResultPrinter.php"-->
              processIsolation="false"

--- a/src/database.rst
+++ b/src/database.rst
@@ -40,7 +40,8 @@ PHPUnit et où vous vous retrouvez bloqué par l'un des problèmes suivants :
 
 L'extension DbUnit simplifie considérablement la configuration d'une base de données à des fins
 de test et vous permet de vérifier le contenu d'une base de données après avoir
-réalisé une suite d'opérations.
+réalisé une suite d'opérations. L'installation de l'extension DbUnit est
+facile et documentée dans :ref:`installation.optional-packages`
 
 .. _database.supported-vendors-for-database-testing:
 

--- a/src/database.rst
+++ b/src/database.rst
@@ -48,8 +48,8 @@ Systèmes gérés pour tester des bases de données
 ###############################################
 
 DbUnit gère actuellement MySQL, PostgreSQL, Oracle et SQLite. Via
-l'intégration de `Zend Framework <http://framework.zend.com>`_ ou de
-`Doctrine 2 <http://www.doctrine-project.org>`_
+l'intégration de `Zend Framework <https://framework.zend.com>`_ ou de
+`Doctrine 2 <https://www.doctrine-project.org>`_
 il est possible d'accéder à d'autres systèmes de base de données comme IBM DB2 ou
 Microsoft SQL Server.
 
@@ -115,7 +115,7 @@ des tests qui ne font pas appel à une base de données, vous pouvez facilement 
 d'une minute, même pour de grandes séries de tests.
 
 La suite de test du
-`projet Doctrine 2 <http://www.doctrine-project.org>`_, par exemple, possède actuellement une suite de tests d'environ 1000 tests
+`projet Doctrine 2 <https://www.doctrine-project.org>`_, par exemple, possède actuellement une suite de tests d'environ 1000 tests
 dont presque la moitié accède à la base de données et continue à s'exécuter en 15
 secondes sur une base de données MySQL sur un ordinateur de
 bureau standard.
@@ -312,7 +312,7 @@ au test de base de données.
 #.
 
    Si vous utilisez des bibliothèques comme
-   `Doctrine 2 <http://www.doctrine-project.org>`_ ou
+   `Doctrine 2 <https://www.doctrine-project.org>`_ ou
    `Propel <http://www.propelorm.org/>`_
    vous pouvez utiliser leurs APIs pour créer le schéma de base de données dont
    vous avez besoin une fois avant de lancer vos tests. Vous pouvez utiliser les possibilités apportées par
@@ -1586,7 +1586,7 @@ Non, PHPUnit exige que tous les objets de base de données soit disponible quand
 la suite démarre. La base de données, les tables, les séquences, les triggers et les
 vues doivent être créés avant que vous exécutiez la suite de tests.
 
-`Doctrine 2 <http://www.doctrine-project.org>`_ ou
+`Doctrine 2 <https://www.doctrine-project.org>`_ ou
 `eZ Components <http://www.ezcomponents.org>`_ possèdent
 des outils puissants qui vous permettent de créer le schéma de base de données
 à partir de structures de données définies préalablement, cependant, ceux-ci

--- a/src/installation.rst
+++ b/src/installation.rst
@@ -123,7 +123,7 @@ Pour les environments shell Cygwin et/ou MingW32 (ex: TortoiseGit), vous
 passer l'étape 5. ci-dessus, il suffit de sauvegarder le fichier
 :file:`phpunit` (sans l'extension :file:`.phar`),
 et de le rendre exécutable via
-chmod 775 phpunit.
+``chmod 775 phpunit``.
 
 .. _installation.phar.verification:
 
@@ -303,5 +303,3 @@ Les packages optionnels suivants sont disponibles:
     .. code-block:: bash
 
         composer require --dev phpunit/dbunit
-
-

--- a/src/risky-tests.rst
+++ b/src/risky-tests.rst
@@ -77,12 +77,16 @@ plus de 10 secondes à s'exécuter. Ce délai d'exécution est configurable via 
 ``timeoutForMediumTests`` dans le fichier
 de configuration XML.
 
-Un test qui n'est pas annoté avec ``@medium`` ou
-``@large`` sera traité comme s'il était annoté avec
-``@small``. Un test "small" échouera s'il prend
+Un test annoté avec ``@small`` échouera s'il prend
 plus de 1 seconde à s'exécuter. Ce délai d'exécution est configurable via
-l'attribut ``timeoutForMediumTests`` dans le fichier de
+l'attribut ``timeoutForSmallTests`` dans le fichier de
 configuration XML.
+
+.. admonition:: Note
+
+   Les tests doivent être explicitement annotés par ``@small``,
+   ``@medium`` ou ``@large`` pour activer les limites de temps d'exécution.
+
 
 .. _risky-tests.global-state-manipulation:
 

--- a/src/risky-tests.rst
+++ b/src/risky-tests.rst
@@ -64,7 +64,7 @@ paquet ``PHP_Invoker`` est installé et que
 l'extension ``pcntl`` est disponible. L'application de cette
 limite de temps peut être activée en utilisant
 l'option ``--enforce-time-limit`` sur la ligne de commande ou en
-définissant ``beStrictAboutTestSize="true"`` dans le fichier de
+définissant ``enforceTimeLimit="true"`` dans le fichier de
 configuration XML de PHPUnit.
 
 Un test annoté avec ``@large`` échouera s'il prend
@@ -94,5 +94,3 @@ peut être activé en utilisant l'option ``--strict-global-state``
 de la ligne de commande ou en définissant
 ``beStrictAboutChangesToGlobalState="true"`` dans le fichier de
 configuration XML de PHPUnit.
-
-

--- a/src/test-doubles.rst
+++ b/src/test-doubles.rst
@@ -48,7 +48,7 @@ retourner une valeur donnée quand elles sont appelées.
 .. admonition:: Limitations: méthodes final, private et static
 
    Merci de noter que les méthodes ``final``, ``private``,
-   ``protected`` et ``static`` ne peuvent pas être remplacées
+   et ``static`` ne peuvent pas être remplacées
    par un bouchon (stub) ou un mock. Elles seront ignorées par la
    fonction de doublure de test de PHPUnit et conserveront leur comportement initial sauf pour
    les méthodes ``static`` qui seront renplacées par une méthode jetant

--- a/src/writing-tests-for-phpunit.rst
+++ b/src/writing-tests-for-phpunit.rst
@@ -591,8 +591,8 @@ Voir :numref:`writing-tests-for-phpunit.data-providers.examples.DependencyAndDat
 
 .. admonition:: Note
 
-   Tous les fournisseurs de données sont exécutés avant le premier appel à la méthode statique ``setUpBeforeClass``
-   et le premier appel à la méthode ``setUp``.
+   Tous les fournisseurs de données sont exécutés avant le premier appel à la méthode statique ``setUpBeforeClass()``
+   et le premier appel à la méthode ``setUp()``.
    De ce fait, vous ne pouvez accéder à aucune variable créée à ces endroits
    depuis un fournisseur de données. Ceci est requis pour que PHPUnit puisse
    calculer le nombre total de tests.
@@ -1003,7 +1003,7 @@ Quand une comparaison échoue, PHPUnit crée une représentation textuelle des
 valeurs d'entrées et les compare. A cause de cette implémentation un diff
 peut montrer plus de problèmes qu'il n'en existe réellement.
 
-Cela arrive seulement lors de l'utilisation de assetEquals ou d'autres fonction
+Cela arrive seulement lors de l'utilisation de ``assertEquals()`` ou d'autres fonctions
 de comparaison "faible" sur les tableaux ou les objets.
 
 .. code-block:: php
@@ -1057,4 +1057,4 @@ de comparaison "faible" sur les tableaux ou les objets.
 
 Dans cet exemple, la différence dans le premier indice entre
 ``1`` et ``'1'``
-est signalée même si AssertEquals considère les valeurs comme une correspondance.
+est signalée même si ``assertEquals()`` considère les valeurs comme une correspondance.


### PR DESCRIPTION

- [x] 25 - [b3de9fa - Removed mapTestClassNameToCoveredClassName](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/b3de9fab4fc49be908100a9485ba39eaf7a88ff4) 
- [x] 23 - [82919 - Mention the "force" parameter for env](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/8291953a9f1ba93fe7215d13c4895a1f4620736f)
- [x] 22 - [09318d - Adding reference link to installation of DbUnit](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/09318dde0ff81ab25f43b7ff939957939bbf1c6a) 
- [x] 21 - [660dc - issue-92 fixed documentation about doubles](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/660dc5c6538a0cb44d42356e96b0cdfc59dfd7bc)  
- [x] 17 - [f06509f - writing-tests-for-phpunit: make syntax highlighting methods](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/f06509fe277586f96dbe98091484611f6e97a6a8) 
- [x] 15 - [d410b - installation: highlight syntax of command](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/d410ba284d24e7826351a6dd23d74d738290ce35) 
- [x] 12 - database: use https for links 
    -  [x] [484dc84 - database: use https for links](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/484dc849ccad4efb0b44169faa9046b184f79776) 
    -  [x] [ba008a - database: use https for links](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/ba008aeed7773b140f34b5119aaebbafa70eb24e) 
- [x] 11 - [57c19c - Fix name of XML configuration file attribute](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/57c19c22d2a4b2df9bb6dd61ba11f0c6d24c948a) 
- [x] 10 - [4f7b270a - Fallback to @Small was removed in PHPUnit 4.7](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/4f7b270adccbd5fd7624c88d49a8e68f0693e85d) 
- [x] 5 - [ea57a20 - Update assertions.rst](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/ea57a208ebbd177f849aadceadda2eead185658e)