### PR TITLE
Synchro  extending-phpunit file (branch 7.0)

### DIFF
--- a/src/extending-phpunit.rst
+++ b/src/extending-phpunit.rst
@@ -140,47 +140,47 @@ montre une implémentation simple de l'interface
 
     class SimpleTestListener implements TestListener
     {
-        public function addError(PHPUnit\Framework\Test $test, Exception $e, $time)
+        public function addError(PHPUnit\Framework\Test $test, \Throwable $e, float $time) : void
         {
             printf("Error while running test '%s'.\n", $test->getName());
         }
 
-        public function addFailure(PHPUnit\Framework\Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)
+        public function addFailure(PHPUnit\Framework\Test $test, PHPUnit\Framework\AssertionFailedError $e, float $time) : void
         {
             printf("Test '%s' failed.\n", $test->getName());
         }
 
-        public function addIncompleteTest(PHPUnit\Framework\Test $test, Exception $e, $time)
+        public function addIncompleteTest(PHPUnit\Framework\Test $test, \Throwable $e, float $time) : void
         {
             printf("Test '%s' is incomplete.\n", $test->getName());
         }
 
-        public function addRiskyTest(PHPUnit\Framework\Test $test, Exception $e, $time)
+        public function addRiskyTest(PHPUnit\Framework\Test $test, \Throwable $e, float $time) : void
         {
             printf("Test '%s' is deemed risky.\n", $test->getName());
         }
 
-        public function addSkippedTest(PHPUnit\Framework\Test $test, Exception $e, $time)
+        public function addSkippedTest(PHPUnit\Framework\Test $test, \Throwable $e, float $time) : void
         {
             printf("Test '%s' has been skipped.\n", $test->getName());
         }
 
-        public function startTest(PHPUnit\Framework\Test $test)
+        public function startTest(PHPUnit\Framework\Test $test) : void
         {
             printf("Test '%s' started.\n", $test->getName());
         }
 
-        public function endTest(PHPUnit\Framework\Test $test, $time)
+        public function endTest(PHPUnit\Framework\Test $test, float $time) : void
         {
             printf("Test '%s' ended.\n", $test->getName());
         }
 
-        public function startTestSuite(PHPUnit\Framework\TestSuite $suite)
+        public function startTestSuite(PHPUnit\Framework\TestSuite $suite) : void
         {
             printf("TestSuite '%s' started.\n", $suite->getName());
         }
 
-        public function endTestSuite(PHPUnit\Framework\TestSuite $suite)
+        public function endTestSuite(PHPUnit\Framework\TestSuite $suite) : void
         {
             printf("TestSuite '%s' ended.\n", $suite->getName());
         }
@@ -204,7 +204,7 @@ tous les autres.
     {
         use TestListenerDefaultImplementation;
 
-        public function endTest(PHPUnit\Framework\Test $test, $time): void
+        public function endTest(PHPUnit\Framework\Test $test, float $time): void
         {
             printf("Test '%s' ended.\n", $test->getName());
         }

--- a/src/extending-phpunit.rst
+++ b/src/extending-phpunit.rst
@@ -34,7 +34,7 @@ de suivre la façon dont PHPUnit implémente ses propres assertions. Comme vous 
 ``assertThat()`` pour évaluation.
 
 .. code-block:: php
-    :caption: Les méthodes assertTrue() et isTrue() de la classe PHPUnit\Framework\Assert
+    :caption: Les méthodes assertTrue() et isTrue() de la classe PHPUnit\\Framework\\Assert
     :name: extending-phpunit.examples.Assert.php
 
     <?php
@@ -80,7 +80,7 @@ abstraite de base pour des objets matcher (ou des contraintes),
 ``PHPUnit\Framework\Constraint``.
 
 .. code-block:: php
-    :caption: La classe PHPUnit_Framework_Constraint_IsTrue
+    :caption: La classe PHPUnit\\Framework\\Constraint\\IsTrue
     :name: extending-phpunit.examples.IsTrue.php
 
     <?php
@@ -223,8 +223,8 @@ des tests.
 
 .. _extending-phpunit.PHPUnit_Framework_Test:
 
-Implémenter PHPUnit\Framework\Test
-##################################
+Implémenter PHPUnit\\Framework\\Test
+####################################
 
 L'interface ``PHPUnit\Framework\Test`` est restreinte et
 facile à implémenter. Vous pouvez écrire une implémentation de

--- a/src/extending-phpunit.rst
+++ b/src/extending-phpunit.rst
@@ -204,7 +204,7 @@ tous les autres.
     {
         use TestListenerDefaultImplementation;
 
-        public function endTest(PHPUnit\Framework\Test $test, $time): time
+        public function endTest(PHPUnit\Framework\Test $test, $time): void
         {
             printf("Test '%s' ended.\n", $test->getName());
         }

--- a/src/extending-phpunit.rst
+++ b/src/extending-phpunit.rst
@@ -140,7 +140,7 @@ montre une implémentation simple de l'interface
 
     class SimpleTestListener implements TestListener
     {
-        public function addError(PHPUnit\Framework\Test $test, \Throwable $e, float $time) : void
+        public function addError(PHPUnit\Framework\Test $test, \Throwable $e, float $time): void
         {
             printf("Error while running test '%s'.\n", $test->getName());
         }
@@ -150,42 +150,42 @@ montre une implémentation simple de l'interface
             printf("Warning while running test '%s'.\n", $test->getName());
         }
 
-        public function addFailure(PHPUnit\Framework\Test $test, PHPUnit\Framework\AssertionFailedError $e, float $time) : void
+        public function addFailure(PHPUnit\Framework\Test $test, PHPUnit\Framework\AssertionFailedError $e, float $time): void
         {
             printf("Test '%s' failed.\n", $test->getName());
         }
 
-        public function addIncompleteTest(PHPUnit\Framework\Test $test, \Throwable $e, float $time) : void
+        public function addIncompleteTest(PHPUnit\Framework\Test $test, \Throwable $e, float $time): void
         {
             printf("Test '%s' is incomplete.\n", $test->getName());
         }
 
-        public function addRiskyTest(PHPUnit\Framework\Test $test, \Throwable $e, float $time) : void
+        public function addRiskyTest(PHPUnit\Framework\Test $test, \Throwable $e, float $time): void
         {
             printf("Test '%s' is deemed risky.\n", $test->getName());
         }
 
-        public function addSkippedTest(PHPUnit\Framework\Test $test, \Throwable $e, float $time) : void
+        public function addSkippedTest(PHPUnit\Framework\Test $test, \Throwable $e, float $time): void
         {
             printf("Test '%s' has been skipped.\n", $test->getName());
         }
 
-        public function startTest(PHPUnit\Framework\Test $test) : void
+        public function startTest(PHPUnit\Framework\Test $test): void
         {
             printf("Test '%s' started.\n", $test->getName());
         }
 
-        public function endTest(PHPUnit\Framework\Test $test, float $time) : void
+        public function endTest(PHPUnit\Framework\Test $test, float $time): void
         {
             printf("Test '%s' ended.\n", $test->getName());
         }
 
-        public function startTestSuite(PHPUnit\Framework\TestSuite $suite) : void
+        public function startTestSuite(PHPUnit\Framework\TestSuite $suite): void
         {
             printf("TestSuite '%s' started.\n", $suite->getName());
         }
 
-        public function endTestSuite(PHPUnit\Framework\TestSuite $suite) : void
+        public function endTestSuite(PHPUnit\Framework\TestSuite $suite): void
         {
             printf("TestSuite '%s' ended.\n", $suite->getName());
         }

--- a/src/extending-phpunit.rst
+++ b/src/extending-phpunit.rst
@@ -145,6 +145,11 @@ montre une implémentation simple de l'interface
             printf("Error while running test '%s'.\n", $test->getName());
         }
 
+        public function addWarning(PHPUnit\Framework\Test $test, PHPUnit\Framework\Warning $e, float $time): void
+        {
+            printf("Warning while running test '%s'.\n", $test->getName());
+        }
+
         public function addFailure(PHPUnit\Framework\Test $test, PHPUnit\Framework\AssertionFailedError $e, float $time) : void
         {
             printf("Test '%s' failed.\n", $test->getName());

--- a/src/extending-phpunit.rst
+++ b/src/extending-phpunit.rst
@@ -187,22 +187,24 @@ montre une implémentation simple de l'interface
     }
 
 
-:numref:`extending-phpunit.examples.BaseTestListener.php`
-montre comment étendre la classe abstraite
-``PHPUnit\Framework\BaseTestListener``, qui permet de spécifier uniquement les méthodes d'interface
+:numref:`extending-phpunit.examples.ExtendedTestListener.php`
+montre comment utiliser le trait
+``PHPUnit\Framework\TestListenerDefaultImplementation``, qui permet de spécifier uniquement les méthodes d'interface
 qui sont intéressantes pour votre cas d'utilisation, tout en fournissant des implémentations vides pour
 tous les autres.
 
 .. code-block:: php
-    :caption: Utiliser BaseTestListener
-    :name: extending-phpunit.examples.BaseTestListener.php
+    :caption: Utiliser le trait TestListenerDefaultImplementation
+    :name: extending-phpunit.examples.ExtendedTestListener.php
 
     <?php
-    use PHPUnit\Framework\BaseTestListener;
+    use PHPUnit\Framework\TestListenerDefaultImplementation;
 
-    class ShortTestListener extends BaseTestListener
+    class ShortTestListener
     {
-        public function endTest(PHPUnit\Framework\Test $test, $time)
+        use TestListenerDefaultImplementation;
+
+        public function endTest(PHPUnit\Framework\Test $test, $time): time
         {
             printf("Test '%s' ended.\n", $test->getName());
         }
@@ -315,5 +317,3 @@ et la seconde valeur celle constatée.
 
     FAILURES!
     Tests: 2, Failures: 1.
-
-

--- a/src/extending-phpunit.rst
+++ b/src/extending-phpunit.rst
@@ -203,9 +203,10 @@ tous les autres.
     :name: extending-phpunit.examples.ExtendedTestListener.php
 
     <?php
+    use PHPUnit\Framework\TestListener;
     use PHPUnit\Framework\TestListenerDefaultImplementation;
 
-    class ShortTestListener
+    class ShortTestListener implements TestListener
     {
         use TestListenerDefaultImplementation;
 


### PR DESCRIPTION
WIP - Do not merge

  - [x] 16 - [4ff19db9 - extending-phpunit: fixes](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/4ff19db9547ef68b9cc82e7b8ea377b5df7a8f69)
  - [x] 8 - [7ff88cb - extending-phpunit: fix code style](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/7ff88cb39efce57acbd7a9d6e1b8d2fe41b0f491)
  - [x] 7 - [2e6b03 - ShortTestListener - add missing interface implementation](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/2e6b036bec54be50148fd97baded0526a4bed6f0)
  - [x] 6 - [544cae5 - SimpleTestListener - add missing addWarning method](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/544cae52793bae63e9db740b8312c330995f70b9)
  - [x] 3 - [252113 - Adds required typhinting to extending listener section](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/2521134b6d8381c2cb9d65fafa23cb394d16f8a2)
  - [x] 2 - [224c21 -  Sincerest apologies - :void is what should have been in the example ](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/224c21ae4b81299e5ea04e697fc3f61b05712930)
  - [x] 1 - [0e56bfd - Remove BaseTestListener documentation ](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/0e56bfd0a3c8f1cbfeb05e5fa5f3dd55900c0432)
