### PR TITLE
synchro  (branch 7.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-build/
+/build
+/node_modules
+/package-lock.json
+

--- a/.textlintrc
+++ b/.textlintrc
@@ -1,0 +1,15 @@
+{
+  "filters": {},
+  "plugins": [
+    "rst"
+  ],
+  "rules": {
+    "alex": true,
+    "common-misspellings": true,
+    "en-capitalization": true,
+    "no-todo": true,
+    "stop-words": true,
+    "terminology": true,
+    "write-good": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -39,11 +39,25 @@ dépôt officiel.
 
 ### Générer la documentation HTML
 
-    make html
+Pour générer la documentation, exécuter la ligne de commande suivante:
 
-### Sortie
+```
+$ make html
+```
 
 Ensuite, vous trouverez les fichiers HTML dans `build/html`.
+
+### Relecture automatisée
+
+####  Installation
+```
+$ pip install docutils-ast-writer
+$ npm install
+```
+#### Utilisation
+```
+$ ./node_modules/.bin/textlint src
+```
 
 ## Contribuer
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "phpunit-documentation-english",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sebastianbergmann/phpunit-documentation-english.git"
+  },
+  "license": "CC-BY-3.0",
+  "devDependencies": {
+    "textlint": "^11.0.1",
+    "textlint-rule-alex": "^1.3.1",
+    "textlint-rule-common-misspellings": "^1.0.1",
+    "textlint-rule-en-capitalization": "^2.0.1",
+    "textlint-rule-no-todo": "^2.0.1",
+    "textlint-rule-stop-words": "^1.0.5",
+    "textlint-rule-terminology": "^1.1.29",
+    "textlint-rule-write-good": "^1.6.2"
+  },
+  "dependencies": {
+    "textlint-plugin-rst": "^0.1.1"
+  }
+}

--- a/src/assertions.rst
+++ b/src/assertions.rst
@@ -2168,6 +2168,10 @@ Le format de chaine peut contenir les arguments suivants:
 
   ``%c``: Un caractère unique quel qu'il soit.
 
+-
+
+  ``%%``: Le symbole pourcentage : ``%``.
+
 .. _appendixes.assertions.assertStringMatchesFormatFile:
 
 assertStringMatchesFormatFile()


### PR DESCRIPTION
- [x] 27 - [01885 - Initial work on proofreading automation](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/01885d8b388aaa6303e8e6fd648394f15f782e09)
- [x] 20 - [076c1a - Document escaped % in assertStringNotMatchesFormat](https://github.com/sebastianbergmann/phpunit-documentation-english/commit/076c1a686ae594d2374de0608e4345118b5f772e)